### PR TITLE
Function changes

### DIFF
--- a/src/fake_adapter.rs
+++ b/src/fake_adapter.rs
@@ -116,6 +116,52 @@ impl FakeBluetoothAdapter {
 
     make_setter!(set_devices, devices, Vec<Arc<FakeBluetoothDevice>>);
 
+    make_getter!(get_ad_datas, ad_datas, Vec<String>);
+
+    make_setter!(set_ad_datas, ad_datas, Vec<String>);
+
+    make_getter!(get_address, address, String);
+
+    make_setter!(set_address, address, String);
+
+    make_getter!(get_name, name, String);
+
+    make_setter!(set_name, name, String);
+
+    make_getter!(get_alias, alias, String);
+
+    make_setter!(set_alias, alias, String);
+
+    make_getter!(get_class, class, u32);
+
+    make_setter!(set_class, class, u32);
+
+    make_getter!(is_discoverable);
+
+    make_setter!(set_discoverable, is_discoverable, bool);
+
+    make_getter!(is_pairable);
+
+    make_setter!(set_pairable, is_pairable, bool);
+
+    make_getter!(get_pairable_timeout, pairable_timeout, u32);
+
+    make_setter!(set_pairable_timeout, pairable_timeout, u32);
+
+    make_getter!(get_discoverable_timeout, discoverable_timeout, u32);
+
+    make_setter!(set_discoverable_timeout, discoverable_timeout, u32);
+
+    make_getter!(is_discovering);
+
+    make_setter!(set_discovering, is_discovering, bool);
+
+    make_getter!(get_uuids, uuids, Vec<String>);
+
+    make_setter!(set_uuids, uuids, Vec<String>);
+
+    make_setter!(set_modalias, modalias, String);
+
     pub fn get_device(&self, id: String) -> Result<Arc<FakeBluetoothDevice>, Box<Error>> {
         let devices = try!(self.get_devices());
         for device in devices {
@@ -154,10 +200,6 @@ impl FakeBluetoothAdapter {
         Ok(devices.push(device))
     }
 
-    make_getter!(get_ad_datas, ad_datas, Vec<String>);
-
-    make_setter!(set_ad_datas, ad_datas, Vec<String>);
-
     pub fn get_first_ad_data(&self) -> Result<String, Box<Error>> {
         let ad_datas = try!(self.get_ad_datas());
         if ad_datas.is_empty() {
@@ -166,49 +208,9 @@ impl FakeBluetoothAdapter {
         Ok(ad_datas[0].clone())
     }
 
-    make_getter!(get_address, address, String);
-
-    make_setter!(set_address, address, String);
-
-    make_getter!(get_name, name, String);
-
-    make_setter!(set_name, name, String);
-
      pub fn create_discovery_session(&self) -> Result<FakeBluetoothDiscoverySession, Box<Error>> {
         FakeBluetoothDiscoverySession::create_session(Arc::new(self.clone()))
     }
-
-    make_getter!(get_alias, alias, String);
-
-    make_setter!(set_alias, alias, String);
-
-    make_getter!(get_class, class, u32);
-
-    make_setter!(set_class, class, u32);
-
-    make_getter!(is_discoverable);
-
-    make_setter!(set_discoverable, is_discoverable, bool);
-
-    make_getter!(is_pairable);
-
-    make_setter!(set_pairable, is_pairable, bool);
-
-    make_getter!(get_pairable_timeout, pairable_timeout, u32);
-
-    make_setter!(set_pairable_timeout, pairable_timeout, u32);
-
-    make_getter!(get_discoverable_timeout, discoverable_timeout, u32);
-
-    make_setter!(set_discoverable_timeout, discoverable_timeout, u32);
-
-    make_getter!(is_discovering);
-
-    make_setter!(set_discovering, is_discovering, bool);
-
-    make_getter!(get_uuids, uuids, Vec<String>);
-
-    make_setter!(set_uuids, uuids, Vec<String>);
 
     pub fn get_modalias(&self) ->  Result<(String, u32, u32, u32), Box<Error>> {
         let cloned = self.modalias.clone();
@@ -228,8 +230,6 @@ impl FakeBluetoothAdapter {
         (product[0] as u32) * 16 * 16 + (product[1] as u32),
         (device[0] as u32) * 16 * 16 + (device[1] as u32)))
     }
-
-    make_setter!(set_modalias, modalias, String);
 
     pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
         let (vendor_id_source,_,_,_) = try!(self.get_modalias());

--- a/src/fake_characteristic.rs
+++ b/src/fake_characteristic.rs
@@ -62,10 +62,6 @@ impl FakeBluetoothGATTCharacteristic {
 
     make_setter!(set_uuid, uuid, String);
 
-    pub fn get_service(&self) -> Result<Arc<FakeBluetoothGATTService>, Box<Error>> {
-        Ok(self.service.clone())
-    }
-
     make_getter!(get_value, value, Vec<u8>);
 
     make_setter!(set_value, value, Vec<u8>);
@@ -74,14 +70,6 @@ impl FakeBluetoothGATTCharacteristic {
 
     make_setter!(set_notifying, is_notifying, bool);
 
-    pub fn start_notify(&self) -> Result<(), Box<Error>> {
-        self.set_notifying(true)
-    }
-
-    pub fn stop_notify(&self) -> Result<(), Box<Error>> {
-        self.set_notifying(false)
-    }
-
     make_getter!(get_flags, flags, Vec<String>);
 
     make_setter!(set_flags, flags, Vec<String>);
@@ -89,6 +77,18 @@ impl FakeBluetoothGATTCharacteristic {
     make_getter!(get_gatt_descriptor_structs, gatt_descriptors, Vec<Arc<FakeBluetoothGATTDescriptor>>);
 
     make_setter!(set_gatt_descriptors, gatt_descriptors, Vec<Arc<FakeBluetoothGATTDescriptor>>);
+
+    pub fn get_service(&self) -> Result<Arc<FakeBluetoothGATTService>, Box<Error>> {
+        Ok(self.service.clone())
+    }
+
+    pub fn start_notify(&self) -> Result<(), Box<Error>> {
+        self.set_notifying(true)
+    }
+
+    pub fn stop_notify(&self) -> Result<(), Box<Error>> {
+        self.set_notifying(false)
+    }
 
     pub fn get_gatt_descriptors(&self) -> Result<Vec<String>, Box<Error>> {
         let cloned = self.gatt_descriptors.clone();

--- a/src/fake_descriptor.rs
+++ b/src/fake_descriptor.rs
@@ -53,10 +53,6 @@ impl FakeBluetoothGATTDescriptor {
 
     make_setter!(set_uuid, uuid, String);
 
-    pub fn get_characteristic(&self) -> Result<Arc<FakeBluetoothGATTCharacteristic>, Box<Error>> {
-        Ok(self.characteristic.clone())
-    }
-
     make_getter!(get_value, value, Vec<u8>);
 
     make_setter!(set_value, value, Vec<u8>);
@@ -64,6 +60,10 @@ impl FakeBluetoothGATTDescriptor {
     make_getter!(get_flags, flags, Vec<String>);
 
     make_setter!(set_flags, flags, Vec<String>);
+
+    pub fn get_characteristic(&self) -> Result<Arc<FakeBluetoothGATTCharacteristic>, Box<Error>> {
+        Ok(self.characteristic.clone())
+    }
 
     pub fn read_value(&self) -> Result<Vec<u8>, Box<Error>> {
         self.get_value()

--- a/src/fake_device.rs
+++ b/src/fake_device.rs
@@ -110,10 +110,6 @@ impl FakeBluetoothDevice {
 
     make_setter!(set_id, id);
 
-    pub fn get_adapter(&self) -> Result<Arc<FakeBluetoothAdapter>, Box<Error>> {
-        Ok(self.adapter.clone())
-    }
-
     make_getter!(get_address, address, String);
 
     make_setter!(set_address, address, String);
@@ -142,14 +138,6 @@ impl FakeBluetoothDevice {
 
     make_setter!(set_paired, is_paired, bool);
 
-    pub fn pair(&self) -> Result<(), Box<Error>> {
-        self.set_paired(true)
-    }
-
-    pub fn cancel_pairing(&self) -> Result<(), Box<Error>> {
-        self.set_paired(false)
-    }
-
     make_getter!(is_connectable);
 
     make_setter!(set_connectable, is_connectable, bool);
@@ -174,6 +162,30 @@ impl FakeBluetoothDevice {
 
     make_setter!(set_legacy_pairing, is_legacy_pairing, bool);
 
+    make_setter!(set_modalias, modalias, String);
+
+    make_getter!(get_rssi, rssi, i16);
+
+    make_setter!(set_rssi, rssi, i16);
+
+    make_getter!(get_tx_power, tx_power, i16);
+
+    make_setter!(set_tx_power, tx_power, i16);
+
+    make_setter!(set_gatt_services, gatt_services, Vec<Arc<FakeBluetoothGATTService>>);
+
+    pub fn get_adapter(&self) -> Result<Arc<FakeBluetoothAdapter>, Box<Error>> {
+        Ok(self.adapter.clone())
+    }
+
+    pub fn pair(&self) -> Result<(), Box<Error>> {
+        self.set_paired(true)
+    }
+
+    pub fn cancel_pairing(&self) -> Result<(), Box<Error>> {
+        self.set_paired(false)
+    }
+
     pub fn get_modalias(&self) ->  Result<(String, u32, u32, u32), Box<Error>> {
         let cloned = self.modalias.clone();
         let modalias = match cloned.lock() {
@@ -192,8 +204,6 @@ impl FakeBluetoothDevice {
         (product[0] as u32) * 16 * 16 + (product[1] as u32),
         (device[0] as u32) * 16 * 16 + (device[1] as u32)))
     }
-
-    make_setter!(set_modalias, modalias, String);
 
     pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
         let (vendor_id_source,_,_,_) = try!(self.get_modalias());
@@ -214,14 +224,6 @@ impl FakeBluetoothDevice {
         let (_,_,_,device_id) = try!(self.get_modalias());
         Ok(device_id)
     }
-
-    make_getter!(get_rssi, rssi, i16);
-
-    make_setter!(set_rssi, rssi, i16);
-
-    make_getter!(get_tx_power, tx_power, i16);
-
-    make_setter!(set_tx_power, tx_power, i16);
 
     pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<Error>> {
         if !(try!(self.is_connected())) {
@@ -248,8 +250,6 @@ impl FakeBluetoothDevice {
         };
         Ok(gatt_services)
     }
-
-    make_setter!(set_gatt_services, gatt_services, Vec<Arc<FakeBluetoothGATTService>>);
 
     pub fn get_gatt_service(&self, id: String) -> Result<Arc<FakeBluetoothGATTService>, Box<Error>> {
         let services = try!(self.get_gatt_service_structs());

--- a/src/fake_service.rs
+++ b/src/fake_service.rs
@@ -54,13 +54,23 @@ impl FakeBluetoothGATTService {
 
     make_setter!(set_id, id);
 
-    pub fn get_device(&self) -> Result<Arc<FakeBluetoothDevice>, Box<Error>> {
-        Ok(self.device.clone())
-    }
-
     make_getter!(get_gatt_characteristic_structs, gatt_characteristics, Vec<Arc<FakeBluetoothGATTCharacteristic>>);
 
     make_setter!(set_gatt_characteristics, gatt_characteristics, Vec<Arc<FakeBluetoothGATTCharacteristic>>);
+
+    make_getter!(is_primary);
+
+    make_setter!(set_is_primary, is_primary, bool);
+
+    make_setter!(set_includes, included_services, Vec<Arc<FakeBluetoothGATTService>>);
+
+    make_getter!(get_uuid, uuid, String);
+
+    make_setter!(set_uuid, uuid, String);
+
+    pub fn get_device(&self) -> Result<Arc<FakeBluetoothDevice>, Box<Error>> {
+        Ok(self.device.clone())
+    }
 
     pub fn get_gatt_characteristics(&self) -> Result<Vec<String>, Box<Error>> {
         let cloned = self.gatt_characteristics.clone();
@@ -91,10 +101,6 @@ impl FakeBluetoothGATTService {
         Ok(gatt_characteristics.push(characteristic))
     }
 
-    make_getter!(is_primary);
-
-    make_setter!(set_is_primary, is_primary, bool);
-
     pub fn get_includes(&self) -> Result<Vec<String>, Box<Error>> {
         let cloned = self.included_services.clone();
         let included_services = match cloned.lock() {
@@ -103,11 +109,5 @@ impl FakeBluetoothGATTService {
         };
         Ok(included_services.into_iter().map(|s| s.get_id()).collect())
     }
-
-    make_setter!(set_includes, included_services, Vec<Arc<FakeBluetoothGATTService>>);
-
-    make_getter!(get_uuid, uuid, String);
-
-    make_setter!(set_uuid, uuid, String);
 
 }


### PR DESCRIPTION
Changed the get_uuids() to get the uuids from the struct of the service when invoked, so we don't have to set the uuid vector manually in the tests.
Grouped the methods, the ones created with a macro are first, then the others.
